### PR TITLE
Replace custom Astro Lottie component

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,6 +8,7 @@ import bgWrap from '../assets/navbar/bg-wrap.svg'
 ---
 
 <footer
+	id="contacto"
 	class="relative overflow-clip rounded-t-[3rem] bg-dark-2 px-page-mobile py-24 text-light-1 md:px-page-tablet md:py-12 lg:px-page"
 >
 	<div class="absolute inset-0 z-0 flex items-center justify-center opacity-[2%]">
@@ -24,7 +25,7 @@ import bgWrap from '../assets/navbar/bg-wrap.svg'
 				<ul class="flex flex-col gap-4">
 					<li><Navlinks href="/" text="Inicio" /></li>
 					<li><Navlinks href="/menu/wraps/" text="Menú" /></li>
-					<li><Navlinks href="/contacto/" text="Contacto" /></li>
+					<li><Navlinks href="#contacto" text="Contacto" /></li>
 				</ul>
 				<ul class="class= flex flex-col gap-4 font-light">
 					<li>
@@ -75,3 +76,10 @@ import bgWrap from '../assets/navbar/bg-wrap.svg'
 		</div>
 	</div>
 </footer>
+
+<style>
+	.main-link:hover svg {
+		tranform: translateY(-2px);
+		transition: transform 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+	}
+</style>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -35,7 +35,7 @@ import andCoffee from '../assets/navbar/and-coffee.svg'
 				<Navlinks href="/menu/wraps/" text="Menú" />
 			</li>
 			<li>
-				<Navlinks href="/contacto/" text="Contacto" />
+				<Navlinks href="#contacto" text="Contacto" />
 			</li>
 		</ul>
 		<a class="relative flex justify-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,7 +5,6 @@ import { Icon } from 'astro-icon/components'
 import Layout from '../layouts/Layout.astro'
 import Button from '../components/Button.astro'
 import FAQ from '../components/FAQ.jsx'
-import LottieAnimation from 'astro-integration-lottie/Lottie.astro'
 
 //Asset imports
 import bbqWrap from '../assets/home/bbq-wrap.png'
@@ -18,6 +17,10 @@ import reviews from '../reviews.json'
 	title="The Wrap Co."
 	description="Deliciosos Wraps artesanales y café nacional para acompañar tu día."
 >
+	<script
+		defer
+		is:inline
+		src="https://unpkg.com/@lottiefiles/lottie-player@latest/dist/lottie-player.js"></script>
 	<main class="overflow-x-hidden">
 		<header
 			class="relative h-auto bg-none px-page-mobile pt-32 sm:bg-conic-gradient sm:pt-40 md:bg-none md:px-page-tablet lg:px-page"
@@ -65,12 +68,12 @@ import reviews from '../reviews.json'
 					class="absolute bottom-0 left-0 pb-20 md:pl-page-tablet lg:pl-page"
 				>
 					<div class="hidden h-32 w-32 md:block">
-						<LottieAnimation
+						<lottie-player
 							src="/images/xp-badge.json"
-							autoplay={true}
-							loop={true}
-							transition:persist
-						/>
+							background="transparent"
+							speed="1"
+							loop
+							autoplay></lottie-player>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Now we are using the official lottie-player web component by loading it from a script tag marked with is:inline.

Thie behaviour achieves a consistent load through the navigations despite having View Transitions activated.